### PR TITLE
implemented nohup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 INSTALL_DIR=""
+NOHUP_DIR="/var/log/nohup.out"
 PYPAD_DIR="/usr/bin/pypad"
 MAIN_DIR="/opt/pypad"
 
@@ -8,12 +9,15 @@ function main() {
         read -p "Enter home directory full path: " INSTALL_DIR
         echo "Creating filestructure for pypad"
         echo " "
-        echo "Installing"
-        run_structure >> /var/log/pypad.log
-        echo "All done. Cleaning up. Remove install.sh and directory manually for now."
-        create_files
-        cleanup
-        exit
+        echo "Installing via nohup background process"
+        nohup run_structure &> NOHUP_DIR
+        wait $!
+        echo "All done. Cleaning up. Removing old directories."
+        nohup create_files &> NOHUP_DIR
+        wait $!
+        nohup cleanup &> NOHUP_DIR
+        echo "Use: cat $NOHUP_DIR to read output."
+        exit 1
 }
 
 function run_structure() {
@@ -24,7 +28,7 @@ function run_structure() {
 function create_files() {
         touch $PYPAD_DIR
         chmod +x $PYPAD_DIR
-        echo "python3 $MAIN_DIR/src/main.py" > $PYPAD_DIR
+        echo "sudo python3 $MAIN_DIR/src/main.py" > $PYPAD_DIR
 }
 
 function cleanup() {


### PR DESCRIPTION
Install script places the functions into a background process and the waits for the previously assigned process to execute then will shift to the next until exit. Makes sure the commands don't execute until the previous child finishes. Using nohup for easier logging. Probably implement time date. User may have to remove /var/log/pypad.log