### PR TITLE
Re-open last file used on startup

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@ import platform
 import random
 from widgets.Messagebox import MessageBox
 from utils.config import config_reader
+from utils.lastFileOpen import lastFileOpen, updateLastFileOpen
 from widgets.Tabs import Tabs
 from widgets.Content import Content
 from widgets.Image import Image
@@ -310,6 +311,8 @@ class Main(QMainWindow):
                 self.currentTab.editor.setFocus()  # Setting focus to the tab after we open it
 
             self.pic_opened = False
+
+            updateLastFileOpen(filename)
         except (IsADirectoryError, AttributeError, UnboundLocalError, PermissionError) as E:
             print(E, " on line 346 in the file main.py")
 
@@ -484,7 +487,7 @@ if __name__ == '__main__':
     try:
         file = sys.argv[1]
     except IndexError:  # File not given
-        file = None
+        file = lastFileOpen()
     app.setStyle('Fusion')
     palette = QPalette()
     if choiceIndex == 0:

--- a/src/main.py
+++ b/src/main.py
@@ -34,10 +34,6 @@ class Main(QMainWindow):
         self.tabsOpen = []
         self.pic_opened = False
 
-        if file is not None:
-            self.openFile(file)
-            self.fileNameChange()
-
         self.dialog = MessageBox(self)
 
         self.setWindowIcon(QIcon('resources/Python-logo-notext.svg_.png'))  # Setting the window icon
@@ -515,4 +511,6 @@ if __name__ == '__main__':
     app.setPalette(palette)
     app.setStyleSheet(material_blue)  # uncomment this to have a material blue theme
     ex.show()
+    if file is not None:
+        ex.openFile(file)
     sys.exit(app.exec_())

--- a/src/utils/lastFileOpen.py
+++ b/src/utils/lastFileOpen.py
@@ -1,0 +1,35 @@
+
+def updateLastFileOpen(filepath):
+    """
+        Updates the path in the file that stores the last file edited with PyPad
+        If this config file can't be accessed for any reason it returns False
+    """
+    try:
+        open(filepath, 'w').close()
+    except FileNotFoundError:
+        return False
+
+    with open('resources/lastFile.txt', 'w') as f:
+        f.write(filepath)
+    return True
+
+
+def lastFileOpen():
+    """
+        Returns the path to the last file edited with PyPad
+        If this filepath can't be accessed for any reason it returns None
+    """
+    try:
+        # Path to last file opened is kept in special config file
+        with open('resources/lastFile.txt', 'r') as f:
+            filepath = f.read().strip()
+
+        # Check file will open
+        open(filepath, 'r').close()
+
+        return filepath
+
+    # If ethier open fails return none
+    except FileNotFoundError:
+        print('last-file-open config file not found')
+        return None


### PR DESCRIPTION
## Re-open last file used on start-up

On start-up, open last file edited with PyPad

#### Notes:
* stores path to last file in plaintext file in ```PyPad/src/resources/lastFile.txt```
* to do this I had to fix a bug opening file from first command line arg first
* technicly the file stored in ```PyPad/src/resources/lastFile.txt``` is the last file __opened__ so if you 
    1. open _foo.py_
    2. open _bar.py_
    3. edit _foo.py_
    4. close PyPad
    5. open PyPad
Then the file opened on start-up will be _bar.py_


This is my first contribution to an open source project so if there is anything I've done 
wrong / unconventionally please could you let me know!