### PR TITLE
Improved config.py

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,35 +1,42 @@
 import json
-import os
+import os, logging
 
 def config_reader(theme):
-    json_file = None
+    logger = logging
+    logger.basicConfig(filename="pypad.log", filemode='a', level=logger.INFO)
+    json_file = ['config', 'config1', 'config2']
+    json_file_path = r"../{}.json"
+    default_path = "../"
+
     if theme == 0:
         try:
-            json_file = open("../config.json", "r")
-
-        except FileNotFoundError:
-            print("aaaa")
-            json_file = open("../config.json", "r")
-            print(os.getcwd())
-            os.chdir("../")
-            print(os.getcwd())
+            open(json_file_path.format(json_file[0]), "r")
+        except FileNotFoundError as err:
+            logger.exception(err)
+            logger.log(logger.INFO, "Attempting to correct directory and find config.json")
+            logger.log(logger.INFO, os.getcwd())
+            os.chdir(default_path)
+            open(json_file_path.format(json_file[0]), 'r')
 
     elif theme == 1:
-        json_file = open("../config1.json", "r")
-
+        try:
+            open(json_file_path.format(json_file[1]), "r")
+        except FileNotFoundError as err:
+            logger.exception(err)
+            logger.log(logger.INFO, "Unable to find theme with int 1")
     elif theme == 2:
-        json_file = open("../config.json", "r")
-
+        try:
+            open(json_file_path.format(json_file[2]), "r")
+        except FileNotFoundError as err:
+            logger.exception(err)
+            logger.log(logger.INFO, "Unable to find theme with int 2")
     else:
         print("Error occurred")
-
-    text = json_file.read()
-
+    text = open(json_file_path.format(json_file[theme]), "r").read()
     return json.loads(text)
 
 
 def config_choice(file):
-
     with open(file, 'r') as index_file:
         config_chosen = int(index_file.read())
 


### PR DESCRIPTION
The use of config.py is more universal now and can be moved and edited with minimal interference from dev end.

Exceptions have been improved somehwat and it's fairly repetitive, but this is a good ground to get a standalone logging feature setup for PyPad and can be moved out once ready - the migration will be simple but will take time to make simple.

os.chdir was having problems on some environments grabbing given paths due to permissions. I've added a default path with this and only use that function in one exception when using config_reader(0) as it's the default configs. If it doesn't find them, elif blocks will head to either theme 1 or 2 by default. Most logic was already there, I just polished it.

Lmk if this is a shit push. I plan on using this logging setup for a future standalone log feature.